### PR TITLE
Feature/service generic

### DIFF
--- a/IssueTracker15/IssueTracker15/Repository/Network/NetworkService.swift
+++ b/IssueTracker15/IssueTracker15/Repository/Network/NetworkService.swift
@@ -17,33 +17,11 @@ class NetworkService<T: Codable> {
         }
         
         switch method {
-        case .get:
-            return get(request: request, urgency)
-        case .post:
-            return post(request: request, urgency)
+        case .get, .post:
+            return getSession(urgency).request(request).publishDecodable(type: T.self)
         default:
             return nil
         }
-    }
-    
-    private func get(request: URLRequest, _ urgency: RequestUrgency = .effective ) -> DataResponsePublisher<T>? {
-        guard request.method == .get else {
-            return nil
-        }
-        
-        return getSession(urgency)
-            .request(request)
-            .publishDecodable(type: T.self)
-    }
-    
-    private func post(request: URLRequest, _ urgency: RequestUrgency = .effective) -> DataResponsePublisher<T>? {
-        guard request.method == .post else {
-            return nil
-        }
-        
-        return getSession(urgency)
-            .request(request)
-            .publishDecodable(type: T.self)
     }
     
     private func getSession(_ urgency: RequestUrgency) -> Session {

--- a/IssueTracker15/IssueTracker15/Repository/Repository.swift
+++ b/IssueTracker15/IssueTracker15/Repository/Repository.swift
@@ -12,7 +12,14 @@ import Alamofire
 class Repository {
     static let shared = Repository()
     
-    var networkService = NetworkService<TestDecodableType>()
+    let serviceWrapper = ContainerWrapper(container: ServiceContainer<Any>())
+    
+    func getNetworkService<T: Codable>(resultType: T.Type) -> NetworkService<T>? {
+        let service = NetworkService<T>()
+        
+        serviceWrapper.regist(instance: service)
+        return serviceWrapper.resolve(type: NetworkService<T>.self) as? NetworkService<T>
+    }
 }
 
 enum ServiceType {

--- a/IssueTracker15/IssueTracker15/Repository/ServiceContainer.swift
+++ b/IssueTracker15/IssueTracker15/Repository/ServiceContainer.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Service들을 Repository에서 DI 하고자 만든 클래스. 현재 사용하지 않음.
-class ServiceContainer<S: Transferable>: Resolvable {
+class ServiceContainer<S>: Resolvable {
     
     typealias Value = S
     

--- a/IssueTracker15/IssueTracker15/Test/UseCases/RequestModel.swift
+++ b/IssueTracker15/IssueTracker15/Test/UseCases/RequestModel.swift
@@ -16,7 +16,9 @@ class RequestModel {
     
     static func networkRequest(urgency: RequestUrgency? = nil) -> DataResponsePublisher<TestDecodableType>? {
         // 이전 프로젝트에서 사용한 REST-API를 이용하여 기능 테스트 중입니다.
-        guard let url = URL(string: "https://public.codesquad.kr/jk/boostcamp/starbuckst-loading.json") else { return nil }
+        guard let url = URL(string: "https://public.codesquad.kr/jk/boostcamp/starbuckst-loading.json") else {
+            return nil
+        }
         
         var request = URLRequest(url: url)
         request.method = .get

--- a/IssueTracker15/IssueTracker15/Test/UseCases/RequestModel.swift
+++ b/IssueTracker15/IssueTracker15/Test/UseCases/RequestModel.swift
@@ -23,7 +23,7 @@ class RequestModel {
         
         return Repository
             .shared
-            .networkService
-            .request(request, urgency: urgency ?? .urgent)
+            .getNetworkService(resultType: TestDecodableType.self)?
+            .request(request, urgency: .urgent)
     }
 }

--- a/IssueTracker15/IssueTracker15/Test/UseCases/TestUseCase.swift
+++ b/IssueTracker15/IssueTracker15/Test/UseCases/TestUseCase.swift
@@ -12,25 +12,21 @@ class TestUseCase: UseCaseResponsible {
     
     private var cancellable = Set<AnyCancellable>()
     
-    func requestFromUseCase(_ completionBlock: @escaping (Any?)->Void) {
+    func requestFromUseCase(_ completionBlock: @escaping (Any?) -> Void) {
         RequestModel
             .networkRequest(urgency: .urgent)?
-            .value()
+            .result()
             .subscribe(on: DispatchQueue.global())
-            .sink(
-                receiveCompletion: { completion in
-                    switch completion {
-                    case .failure(let error):
-                        print(error)
-                    case .finished:
-                        print("haha")
-                    }
-                },
-                receiveValue: { data in
-                    print("kaka")
+            .sink(receiveValue: { result in
+                switch result {
+                case .success(let data):
+                    print(data)
                     completionBlock(data)
+                case .failure(let error):
+                    print(error)
+                    completionBlock(error)
                 }
-            )
+            })
             .store(in: &cancellable)
     }
 }

--- a/IssueTracker15/IssueTracker15/Test/UseCases/TestUseCase.swift
+++ b/IssueTracker15/IssueTracker15/Test/UseCases/TestUseCase.swift
@@ -8,9 +8,7 @@ import Combine
 class TestUseCase: UseCaseResponsible {
     
     static let shared = TestUseCase()
-    private var storeCancellable: Set<AnyCancellable> = []
-    
-    private var cancellable = Set<AnyCancellable>()
+    private var cancellables: Set<AnyCancellable> = []
     
     func requestFromUseCase(_ completionBlock: @escaping (Any?) -> Void) {
         RequestModel
@@ -20,13 +18,11 @@ class TestUseCase: UseCaseResponsible {
             .sink(receiveValue: { result in
                 switch result {
                 case .success(let data):
-                    print(data)
                     completionBlock(data)
                 case .failure(let error):
-                    print(error)
                     completionBlock(error)
                 }
             })
-            .store(in: &cancellable)
+            .store(in: &cancellables)
     }
 }


### PR DESCRIPTION
## 🔨 관련 Issue

- SangHwi-Back/issue-tracker#5

## 👨🏻‍💻 작업 내용

1. Service 불러올 때 직접 리턴할 타입을 UseCase가 명시해줍니다.
  - Repository 에서는 서비스를 DIContainer에 regist 합니다.
2. 각 Service 내에서는Generic Type인 T 를 설정하고 최소한의 Protocol 구현만을 정의하고 있습니다.
  - NetworkService 의 경우 T 는 Codable 을 구현해야 합니다.
  - 즉, NetworkService 리턴 타입은 최소 Codable 구현은 해야 하는 것 입니다.

## 💭 고민한 점

UseCase를 유심히 들여다 보니 `requestFromUseCase`라는 메소드만 구현하도록 되어 있는데
예전 피그백 말씀처럼 UseCase 의 의미를 다시 한번 생각하게 되었습니다.
UseCase를 정의할 만한 특성을 고려해서 UseCaseResponsible을 고려해보도록 하겠습니다.